### PR TITLE
Fixed issue where RDataFrame was never built in some cases, added latest ROOT version.

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -26,6 +26,7 @@ class Root(CMakePackage):
     # Development version (when more recent than production).
 
     # Production version
+    version('6.22.00', sha256='efd961211c0f9cd76cf4a486e4f89badbcf1d08e7535bba556862b3c1a80beed')
     version('6.20.04', sha256='1f8c76ccdb550e64e6ddb092b4a7e9d0a10655ef80044828cba12d5e7c874472')
     version('6.20.02', sha256='0997586bf097c0afbc6f08edbffcebf5eb6a4237262216114ba3f5c8087dcba6')
     version('6.20.00', sha256='68421eb0434b38b66346fa8ea6053a0fdc9a6d254e4a72019f4e3633ae118bf0')

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -82,6 +82,8 @@ class Root(CMakePackage):
             description='Enable Aqua interface')
     variant('davix', default=True,
             description='Compile with external Davix')
+    variant('dataframe', default=True,
+            description='Enable ROOT Dataframes')
     variant('emacs', default=False,
             description='Enable Emacs support')
     variant('examples', default=True,
@@ -346,6 +348,7 @@ class Root(CMakePackage):
                 ['cling', True],
                 ['cocoa', 'aqua'],
                 ['davix'],
+                ['dataframe', True],
                 ['dcache', False],
                 ['fftw3', 'fftw'],
                 ['fitsio', 'fits'],


### PR DESCRIPTION
1. It seems that the spack package was never updated after ROOT moved RDataFrame into its own dataframe library. This lead to RDataFrame to not be built on (at least) MacOS. I added a new flag to package.py to allow for RDataFrame to be built.

2. I added the new 6.22.00 ROOT release version.